### PR TITLE
投稿記事一覧の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# 環境変数
+.env
+.env.*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,16 @@
 import "./App.css"
 import "./index.css"
-import { Header } from "@/components/layouts"
-import { Footer } from "@/components/layouts"
+import { Routes, Route } from "react-router"
+import { MainLayout } from "./layouts/MainLayout"
+import { Home } from "./components/features/home/Home"
 
 function App() {
   return (
-    <>
-      <Header isAuthenticated={true} />
-      <div className="flex flex-col items-center justify-center h-screen">
-        <p className="text-2xl font-bold text-center">Hello World</p>
-      </div>
-      <Footer />
-    </>
+    <Routes>
+      <Route element={<MainLayout />}>
+        <Route path="/" element={<Home />} />
+      </Route>
+    </Routes>
   )
 }
 

--- a/src/components/blocks/article-card/ArticleCard.tsx
+++ b/src/components/blocks/article-card/ArticleCard.tsx
@@ -1,0 +1,27 @@
+import { Link } from "react-router"
+import type { ArticleCardProps } from "./ArticleCardProps"
+
+export function ArticleCard({ id, title, createdAt, updatedAt, user }: ArticleCardProps) {
+  return (
+    <>
+      <div className="grid grid-cols-[32px_1fr] grid-rows-2 gap-x-2">
+        <span className="row-span-2 block w-8 h-8 rounded-full overflow-hidden">
+          <img src={user.icon} alt={user.name} width={32} height={32} />
+        </span>
+        <p className="text-sm">{user.name}</p>
+        <p className="text-xs text-[rgba(0,0,0,0.6)]">
+          <time dateTime={updatedAt ?? createdAt}>
+            {updatedAt
+              ? `更新日：${new Date(updatedAt).toLocaleDateString("ja-JP")}`
+              : `作成日：${new Date(createdAt).toLocaleDateString("ja-JP")}`}
+          </time>
+        </p>
+      </div>
+      <div className="mt-2 ml-10">
+        <h3 className="text-xl font-bold">
+          <Link to={`/articles/${id}`}>{title}</Link>
+        </h3>
+      </div>
+    </>
+  )
+}

--- a/src/components/blocks/article-card/ArticleCardProps.ts
+++ b/src/components/blocks/article-card/ArticleCardProps.ts
@@ -1,0 +1,13 @@
+export type ArticleCardProps = {
+  id: string
+  title: string
+  createdAt: string
+  updatedAt?: string
+  user: UserProps
+}
+
+export type UserProps = {
+  id: string
+  name: string
+  icon: string
+}

--- a/src/components/blocks/article-card/index.ts
+++ b/src/components/blocks/article-card/index.ts
@@ -1,0 +1,2 @@
+export * from "./ArticleCard"
+export * from "./ArticleCardProps"

--- a/src/components/blocks/index.ts
+++ b/src/components/blocks/index.ts
@@ -1,1 +1,2 @@
 export * from "./search-box"
+export * from "./article-card"

--- a/src/components/features/home/Home.tsx
+++ b/src/components/features/home/Home.tsx
@@ -1,0 +1,16 @@
+import { ArticleList } from "./components/article-list"
+import { useArticle } from "./hooks/use-article"
+
+export function Home() {
+  const { items, loading, error } = useArticle(20)
+
+  if (loading) return <div>読み込み中…</div>
+  if (loading) return <div>エラー：{error}</div>
+
+  return (
+    <>
+      <h2 className="font-bold">記事一覧</h2>
+      <ArticleList items={items} />
+    </>
+  )
+}

--- a/src/components/features/home/components/article-list/ArticleList.tsx
+++ b/src/components/features/home/components/article-list/ArticleList.tsx
@@ -1,0 +1,14 @@
+import { ArticleCard } from "@/components/blocks/article-card/ArticleCard"
+import type { ArticleListProps } from "./ArticleListProps"
+
+export function ArticleList({ items }: ArticleListProps) {
+  return (
+    <ul className="space-y-6">
+      {items.map(item => (
+        <li key={item.id} className="bg-white pt-4 px-6 rounded-xl">
+          <ArticleCard {...item} />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/features/home/components/article-list/ArticleListProps.ts
+++ b/src/components/features/home/components/article-list/ArticleListProps.ts
@@ -1,0 +1,7 @@
+import type { ArticleCardProps } from "@/components/blocks"
+
+export type ArticleListItem = ArticleCardProps
+
+export type ArticleListProps = {
+  items: ArticleListItem[]
+}

--- a/src/components/features/home/components/article-list/index.ts
+++ b/src/components/features/home/components/article-list/index.ts
@@ -1,0 +1,2 @@
+export * from "./ArticleList"
+export * from "./ArticleListProps"

--- a/src/components/features/home/hooks/use-article.tsx
+++ b/src/components/features/home/hooks/use-article.tsx
@@ -1,0 +1,67 @@
+import type { ArticleCardProps } from "@/components/blocks"
+import { useEffect, useState } from "react"
+
+// Qiita APIのURL
+const QIITA_API_ITEMS_URL = "https://qiita.com/api/v2/items"
+
+// 1ページあたり表示件数のデフォルトは20件
+export function useArticle(perPage: number = 20) {
+  // 記事の配列を管理するstate
+  const [items, setItems] = useState<ArticleCardProps[]>([])
+  // 読み込み中かどうかを管理するstate
+  const [loading, setLoading] = useState(true)
+  // エラー情報を管理するstate
+  const [error, setError] = useState<string | null>(null)
+
+  // コンポーネントがマウントされた時、またはperPageが変わった時にAPIを呼ぶ
+  useEffect(() => {
+    // 非同期関数でAPI呼び出し
+    async function fetchArticles() {
+      try {
+        // Qiita APIを呼び出す
+        const response = await fetch(`${QIITA_API_ITEMS_URL}?page=1&per_page=${perPage}`, {
+          headers: {
+            // アクセストークンをAuthorizationヘッダーに設定
+            Authorization: `Bearer ${import.meta.env.VITE_QIITA_TOKEN}`,
+          },
+        })
+
+        // レスポンスが失敗（ステータスコードが200系以外）の場合はエラーを投げる
+        if (!response.ok) {
+          throw new Error(`Qiita API 取得エラー：${response.status}`)
+        }
+
+        // JSONをパース
+        const data = await response.json()
+
+        // APIのレスポンスをArticleCardProps型に変換
+        const mapped: ArticleCardProps[] = data.map((item: any) => ({
+          id: item.id,
+          title: item.title,
+          createdAt: item.created_at,
+          updatedAt: item.updated_at,
+          url: item.url,
+          user: {
+            id: item.user.id,
+            name: item.user.name,
+            icon: item.user.profile_image_url,
+          },
+        }))
+
+        // stateにセットしてコンポーネントを再レンダリング
+        setItems(mapped)
+      } catch (e) {
+        // エラー発生時はerror stateにセット
+        setError(e instanceof Error ? e.message : "不明なエラー")
+      } finally {
+        // 成功・失敗に関わらずloadingをfalseに
+        setLoading(false)
+      }
+    }
+
+    // fetchArticlesを呼び出す
+    fetchArticles()
+  }, [perPage])
+
+  return { items, loading, error }
+}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from "react-router"
+import { Header } from "@/components/layouts"
+import { Footer } from "@/components/layouts"
+
+export function MainLayout() {
+  return (
+    <>
+      <Header isAuthenticated={true} />
+      <main className="max-w-[1640px] min-h-screen py-3 px-4 flex flex-col">
+        <Outlet />
+      </main>
+      <Footer />
+    </>
+  )
+}


### PR DESCRIPTION
## 概要
#10
投稿記事一覧の実装

## 対応内容
- レイアウト構成を修正
- 記事のカードコンポーネントを作成
- トップページに記事一覧コンポーネントを作成
- Qiita APIを使用してQiitaの記事を取得、表示する
